### PR TITLE
Automate deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+permissions:
+  contents: write
+jobs:
+  main:
+    name: Build and push to branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: dist
+          clean: true

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The landing page for Rhinoverse: a collection of open-source R packages for enterprise Shiny apps.
 
-## <u>Development</u>
+## Development
 
 Install all the necessary dependencies based on package.json file:
 ```
@@ -18,7 +18,7 @@ Open [http://localhost:9000](http://localhost:9000) to view it in the browser.
 The page will reload if you make edits. You will also see any lint errors in the console.
 
 
-## <u>Editing Content</u>
+## Editing content
 
 Grid of hexagonal cells and packages descriptions are generated dynamically in JS. In order to **edit packages content**, like descriptions and links, or to **add new package** to the landing page, you basically need to modify `libraries.js` and/or `hexData.js` files.
 
@@ -52,9 +52,6 @@ To have more clear visual representiation of hexagonal grid in code, it's recomm
 
 If you are adding a new package, please provide SVG file with a logo and place it in `static/svg/` directory. SVG file name should be the same as the `id` specified in `libraries.js` and `library` specified in `hexData.js`, in order to be displayed correctly.
 
-## <u>Deployment</u>
-To deploy a newer version of the webpage simply run:
-```
-npm run deploy
-```
-Webpage under [rhinoverse.dev](https://rhinoverse.dev/) domain will be automatically updated.
+## Deployment
+
+The `.github/deploy.yml` workflow will automatically build and deploy the page upon push to `main`.

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
   },
   "scripts": {
     "start": "parcel --open",
-    "build": "parcel build",
-    "deploy": "rm -rf dist && yarn build && cd dist && git init && git add . && git commit -m 'update' && git remote add origin git@github.com:Appsilon/rhinoverse.dev.git && git push --force origin master:gh-pages"
+    "build": "parcel build"
   },
   "browserslist": [
     "> 1%",


### PR DESCRIPTION
### Changes

Add a workflow to automatically deploy to `gh-pages` upon push to `main`. You can see a test run of this workflow [here](https://github.com/Appsilon/rhinoverse.dev/actions/runs/4435452974) (results already pushed to `gh-pages`).