### PR TITLE
Update GA4 in index.html

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -13,13 +13,16 @@
     <!-- build:css styles/main.css -->
     <link rel="stylesheet" href="styles/main.scss">
     <!-- endbuild -->
-    <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-W8JRG3J');</script>
-    <!-- End Google Tag Manager -->
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-FQQZL5V93G"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      
+      gtag('config', 'G-FQQZL5V93G');
+      gtag('config', 'G-279HF9JWT2');
+    </script>
   </head>
   <body>
     <!--[if IE]>


### PR DESCRIPTION
Google Analytics snippet updated from GTM to a GA4 snippet at the bottom of <head>.  Two property ids are added:
- 'G-279HF9JWT2'
- 'G-FQQZL5V93G'

*Have you read the [Contributing Guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md)?*

Issue #

## Changes description

*Clearly and concisely describe what's in this pull request. Include screenshots, if necessary.*
